### PR TITLE
Add name to TourGuideZoneByPosition.

### DIFF
--- a/src/components/TourGuideZoneByPosition.tsx
+++ b/src/components/TourGuideZoneByPosition.tsx
@@ -35,6 +35,7 @@ export const TourGuideZoneByPosition = ({
   right,
   bottom,
   containerStyle,
+  name,
 }: TourGuideZoneByPositionProps) => {
   if (!isTourGuide) {
     return null
@@ -63,6 +64,7 @@ export const TourGuideZoneByPosition = ({
           title,
           subtitle,
           text,
+          name,
         }}
         style={{
           ...zoneStyle,


### PR DESCRIPTION
This is needed so that we can set the current step name from the props name of TourGuideZoneByPosition.